### PR TITLE
fix: add await when calling drainContainerInstance

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -57,7 +57,7 @@ export const handler = async (event, context, callback) => {
     });
   } else if (containerInstanceId != null) {
     // arn:aws:ecs:${region}:${accountId}:container-instance/ecsCluster/${id}
-    drainContainerInstance({
+    await drainContainerInstance({
       clusterName,
       containerInstanceId: containerInstanceId.split("/").slice(-1).pop(),
       region,


### PR DESCRIPTION
`drainContainerInstance` 함수는 promise를 반환하는데 await 구문이 없어서 오류처리가 안될 수 있으므로 await 구문을 추가합니다.